### PR TITLE
Fix a bug when clicking on repost button

### DIFF
--- a/client/src/components/CardMemo.vue
+++ b/client/src/components/CardMemo.vue
@@ -103,10 +103,19 @@ export default {
       return 0;
     },
     memoReposts() {
+      let repostsCount = 0;
       if (this.memo && this.memo.reposts) {
-        return this.memo.reposts;
+        repostsCount = this.memo.reposts;
       }
-      return 0;
+      if (this.queuedMemos) {
+        for (let key in this.queuedMemos) {
+          const memo = this.queuedMemos[key];
+          if (memo.type === "repost" && memo.parent === this.memo.id) {
+            repostsCount++;
+          }
+        }
+      }
+      return repostsCount;
     },
     memoLikes() {
       let likesCount = 0;
@@ -145,9 +154,10 @@ export default {
       return false;
     },
     userReposted() {
-      if (this.memos && this.fromAddress) {
+      const memos = { ...this.memos, ...this.queuedMemos };
+      if (memos && this.fromAddress) {
         return find(
-          this.memos,
+          memos,
           m =>
             m.parent === this.memo.id &&
             m.address === this.fromAddress &&

--- a/client/src/components/InfiniteFeed.vue
+++ b/client/src/components/InfiniteFeed.vue
@@ -1,10 +1,10 @@
 <template lang="pug">
 .infinite-feed
   template(v-if="Object.keys(queued).length > 0")
-    card-memo(v-for="memo in filteredQueued" :memo="memo" :key="memo.id")
+    card-memo(v-for="memo in filteredQueued" v-if="memo.memo && memo.memo.body" :memo="memo" :key="memo.id")
 
   template(v-if="Object.keys(memos).length > 0")
-    card-memo(v-for="memo in filteredMemos" :memo="memo" :key="memo.id")
+    card-memo(v-for="memo in filteredMemos" v-if="memo.memo && memo.memo.body" :memo="memo" :key="memo.id")
     btn-load-more(:account="account")
 
   card-loading(v-else)

--- a/client/src/components/MemoBody.vue
+++ b/client/src/components/MemoBody.vue
@@ -15,7 +15,11 @@ export default {
       let text = this.memo.memo;
       // handle JSON based memos
       if (typeof text === "object") {
-        return h.linkifyMemo(text.body);
+        if (text.type ==="post" && text.body) {
+          return h.linkifyMemo(text.body);
+        } else if (text.type === "repost" && !text.body) {
+          return ""
+        }
       }
       // handle historical slash based memos
       if (text) {


### PR DESCRIPTION
Accounts for reposts stored in `queuedMemos`, which makes repost counter react instantly.

Since reposts are displayed in feed, but as of this moment don't contain body, this adds a conditional to prevent posts from being displayed unless they contain a body. Until it is decided where the join of reposts and their parent's body happens (client or server) this prevents errors in `CardMemo` (which expects a body).

Preview: https://youtu.be/isjfxFFSLto

Fix https://github.com/virgo-project/dither/issues/19