### PR TITLE
Home and Account: fetching data

### DIFF
--- a/client/src/components/InfiniteFeed.vue
+++ b/client/src/components/InfiniteFeed.vue
@@ -1,11 +1,12 @@
 <template lang="pug">
 .infinite-feed
-  template(v-if="Object.keys(queued).length > 0")
+  div(v-if="Object.keys(queued).length > 0")
     card-memo(v-for="memo in filteredQueued" v-if="memo.memo && memo.memo.body" :memo="memo" :key="memo.id")
 
-  template(v-if="Object.keys(memos).length > 0")
-    card-memo(v-for="memo in filteredMemos" v-if="memo.memo && memo.memo.body" :memo="memo" :key="memo.id")
-    btn-load-more(:account="account")
+  div(v-if="Object.keys(memos).length > 0")
+    card-memo(v-for="i in memosVisibleCount" v-if="filteredMemos[i-1] && filteredMemos[i-1].memo.body" :memo="filteredMemos[i-1]" :key="filteredMemos[i-1].id")
+    .btn-load-more(style="btnStyle" v-if="Object.keys(filteredMemos).length >= memosVisibleCount")
+      dc-btn(size="large" @click.native="memosVisibleCount += 10" icon="refresh-cw") Show more
 
   card-message(v-else)
 </template>
@@ -15,12 +16,14 @@ import { orderBy, pickBy, map, uniq } from "lodash";
 import BtnLoadMore from "./BtnLoadMore";
 import CardMessage from "./CardMessage";
 import CardMemo from "./CardMemo";
+import DcBtn from "@/components/DcBtn"
 export default {
   name: "infinite-feed",
   components: {
     BtnLoadMore,
     CardMessage,
-    CardMemo
+    CardMemo,
+    DcBtn
   },
   computed: {
     filteredMemos() {
@@ -52,7 +55,8 @@ export default {
   },
   data: () => ({
     memoTypes: ["post", "repost"],
-    memoTypesComment: ["post", "repost", "comment"]
+    memoTypesComment: ["post", "repost", "comment"],
+    memosVisibleCount: 10
   }),
   methods: {
     filterMemoTypes(memos) {
@@ -102,4 +106,10 @@ export default {
 };
 </script>
 
-<style scoped lang="stylus"></style>
+<style scoped lang="stylus">
+.btn-load-more
+  height 5rem
+  display flex
+  align-items center
+  justify-content center
+</style>

--- a/client/src/views/AccountsAccount.vue
+++ b/client/src/views/AccountsAccount.vue
@@ -113,16 +113,22 @@ export default {
   methods: {
     back() {
       this.$router.go(-1);
+    },
+    async memosOpenDBChannel() {
+      try {
+        await this.$store.dispatch(`memos/openDBChannel`, {
+          orderBy: ["timestamp", "desc"],
+          where: [["address", "==", this.$route.params.address]]
+        });
+      } catch {
+        console.warn("Channel is already open.")
+      }
     }
   },
   mounted() {
-    this.$store.dispatch("memos/fetchAndAdd", {
-      limit: 10,
-      orderBy: ["timestamp", "desc"],
-      where: [["address", "==", this.$route.params.address]]
-    });
+    this.memosOpenDBChannel()
     this.$store.dispatch("accounts/fetchById", this.$route.params.address);
-  }
+  },
 };
 </script>
 

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -7,7 +7,6 @@
       btn-icon(slot="btn-right" type="link" :to="{ name: 'memos-new' }" icon="edit")
     template(v-else)
       btn-icon(slot="btn-right" type="link" :to="{ name: 'login' }" icon="log-in")
-
   infinite-feed(v-if="posts" :memos="posts" :queued="queuedPosts" :following="following")
   card-message(v-else)
 
@@ -23,6 +22,7 @@ import BtnLoadMore from "@/components/BtnLoadMore";
 import CardMessage from "@/components/CardMessage";
 import InfiniteFeed from "@/components/InfiniteFeed";
 import AppHeader from "@/components/AppHeader";
+import CardMemo from "@/components/CardMemo"
 export default {
   name: "page-index",
   components: {
@@ -31,7 +31,8 @@ export default {
     BtnIcon,
     BtnLoadMore,
     CardMessage,
-    InfiniteFeed
+    InfiniteFeed,
+    CardMemo
   },
   computed: {
     ...mapGetters(["memos", "userSignedIn", "queuedMemos", "following"]),
@@ -51,22 +52,23 @@ export default {
     }
   },
   methods: {
-    memosStartStreaming() {
-      this.$store.dispatch("fetchFollowingList").then(following => {
-        console.log("!!!", following)
+    memosOpenDBChannel(following) {
+      following.forEach(async f => {
+        try {
+          await this.$store.dispatch(`memos/openDBChannel`, {
+            where: [
+              ["address", "==", f]
+            ]
+          })
+        } catch {
+          console.warn("Channel is already open.")
+        }
       })
     },
-    memosStopStreaming() {
-      this.$store.dispatch("memos/closeDBChannel")
-    }
   },
-  mounted() {
-    this.memosStartStreaming()
+  async created() {
+    const following = await this.$store.dispatch("fetchFollowingList")
+    this.memosOpenDBChannel(following)
   },
-  destroyed() {
-    this.memosStopStreaming()
-  }
 };
 </script>
-
-<style scoped lang="stylus"></style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -49,6 +49,22 @@ export default {
       }
       return value;
     }
+  },
+  methods: {
+    memosStartStreaming() {
+      this.$store.dispatch("fetchFollowingList").then(following => {
+        console.log("!!!", following)
+      })
+    },
+    memosStopStreaming() {
+      this.$store.dispatch("memos/closeDBChannel")
+    }
+  },
+  mounted() {
+    this.memosStartStreaming()
+  },
+  destroyed() {
+    this.memosStopStreaming()
   }
 };
 </script>


### PR DESCRIPTION
This PR adds data fetching logic to Home and Account page components. This is a first step of moving away from having such logic in App components.

When Home component is mounted, list of `following` accounts is fetched if the user is authenticated, otherwise a list of default accounts is retured. For each following account a real-time connection is opened. Since `openDBChannel` does not have a `limit` option, all memos are streamed and "Show more" button inserts more of them into the DOM.

https://youtu.be/bNWVmt2giTU